### PR TITLE
Match func_8007194C_usa

### DIFF
--- a/include/attack2d.h
+++ b/include/attack2d.h
@@ -9,7 +9,7 @@ struct cursor_t;
 struct tetWell;
 
 void Init2DAttackPosition(struct attack_t *attack, s32 type, s32 num);
-// void func_8007194C_usa();
+void func_8007194C_usa(struct attack_t *attack);
 // void func_8007197C_usa();
 void Update2DAttack(struct tetWell *well, struct cursor_t *cursor, s32 num);
 // void func_80072198_usa();

--- a/src/main/attack2d.c
+++ b/src/main/attack2d.c
@@ -3,6 +3,7 @@
  */
 
 #include "attack2d.h"
+#include "attack.h"
 
 #include "include_asm.h"
 #include "macros_defines.h"
@@ -13,7 +14,14 @@ INCLUDE_ASM("asm/usa/nonmatchings/main/attack2d", Init2DAttackPosition);
 #endif
 
 #if VERSION_USA
-INCLUDE_ASM("asm/usa/nonmatchings/main/attack2d", func_8007194C_usa);
+void func_8007194C_usa(attack_t *attack) {
+    attack->rect.s.imageW = 0x200;
+    attack->rect.s.scaleW = 0x38F;
+    attack->rect.s.imageStride = 8;
+    attack->rect.s.imageFmt = 2;
+    attack->rect.s.imageSiz = 1;
+    attack->rect.s.imageAdrs = 0;
+}
 #endif
 
 #if VERSION_USA


### PR DESCRIPTION
`func_8007194C_usa` is another seemingly unused function. I went with an `attack_t` because the assembly was very similar to the beginning of `Init2DAttackPosition()`, which uses `attack_t`.